### PR TITLE
fix: use hello-world-app as docker build context

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -75,7 +75,8 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
-          context: .
+          context: ./hello-world-app
+          file: ./hello-world-app/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Updates the Docker build context in the GitHub Actions workflow to ./hello-world-app so the correct Dockerfile is used during the build process.